### PR TITLE
[fix] to_flag false positive

### DIFF
--- a/hdl/rtl/EF_TCC32.v
+++ b/hdl/rtl/EF_TCC32.v
@@ -85,7 +85,7 @@ module EF_TCC32 (
     reg			    pwm_out;
     
     assign pwm_out_pin = pwm_out;
-    assign to_flag = up ? (tmr == period) : (tmr == 32'b0);
+    assign to_flag = en & tmr_en & (up ? (tmr == period) : (tmr == 32'b0));
     
     // ctr pin syn
     reg	ctr_in_sync [1:0];


### PR DESCRIPTION
# О чем PR
Исправляю баг при котором флаг тайм-аута (to_flag) ложно активировался, когда таймер был выключен. Это приводило к некорректной работе модуля в связке с шиной APB при обработке прерываний.

Воспроизвести можно следующим образом:
Установить up = 1
Установить tmr = period
Оставить tmr_en = 0
Наблюдать, что to_flag = 1

# Какие изменения он привносит?

Изменение логики формирования сигнала to_flag для учета активности таймера:
```
// Было:
assign to_flag = up ? (tmr == period) : (tmr == 32'b0);

// Стало:
assign to_flag = en & tmr_en & (up ? (tmr == period) : (tmr == 32'b0));
```